### PR TITLE
PDF Toolbar: Don't collapse in case no breakpoint is set

### DIFF
--- a/src/components/pdf-toolbar.tsx
+++ b/src/components/pdf-toolbar.tsx
@@ -153,7 +153,7 @@ const PdfToolbar: React.FC<PdfToolbarProps> = ({
         )}
       </div>
 
-      {collapseButtonsBreakpoint > 0 && width > collapseButtonsBreakpoint ? (
+      {width >= collapseButtonsBreakpoint ? (
         <PdfToolbarTools
           onDownload={onDownload}
           onPrint={onPrint}


### PR DESCRIPTION
This fixes an issue,
where the PDF viewer on the knowledge page collapsed the buttons even though no breakpoint was set, and it shouldn't do so.