### PR TITLE
ChatMessage: Accept invalid JSON source references and process them properly

### DIFF
--- a/src/views/chatbot/ChatMessage.tsx
+++ b/src/views/chatbot/ChatMessage.tsx
@@ -192,9 +192,9 @@ function KnowledgeSourceRenderer({
 
     return parts.map((part, index) => {
       // extract knowledge_id and embedding_id from source reference using named RegEx groups
-      // the following RegEx allows optional spaces and optional quotes around keys
+      // the following RegEx allows optional spaces and optional quotes around keys and values
       const match =
-        /{ ?"?knowledge_id"?: ?"(?<kid>[a-fA-F0-9-]{36})", ?"?embedding_id"?: ?"(?<eid>[a-fA-F0-9-]{36})" ?}/.exec(
+        /{ ?"?knowledge_id"?: ?"?(?<kid>[a-fA-F0-9-]{36})"?, ?"?embedding_id"?: ?"?(?<eid>[a-fA-F0-9-]{36})"? ?}/.exec(
           part,
         );
       if (match?.groups?.kid && match.groups.eid) {

--- a/src/views/chatbot/ChatMessage.tsx
+++ b/src/views/chatbot/ChatMessage.tsx
@@ -188,13 +188,13 @@ function KnowledgeSourceRenderer({
 }: Readonly<KnowledgeSourceRendererProps>) {
   const renderContent = (content: string) => {
     // split by source references
-    const parts = content.split(/(\{[^}]*})/g);
+    const parts = content.split(/(\{[^}]*})|(\([^}]*\))/g);
 
     return parts.map((part, index) => {
       // extract knowledge_id and embedding_id from source reference using named RegEx groups
-      // the following RegEx allows optional spaces and optional quotes around keys and values
+      // the following RegEx allows optional spaces and optional quotes around keys and values, as well as normal brackets instead of {}
       const match =
-        /{ ?"?knowledge_id"?: ?"?(?<kid>[a-fA-F0-9-]{36})"?, ?"?embedding_id"?: ?"?(?<eid>[a-fA-F0-9-]{36})"? ?}/.exec(
+        /[{(] ?"?knowledge_id"?: ?"?(?<kid>[a-fA-F0-9-]{36})"?, ?"?embedding_id"?: ?"?(?<eid>[a-fA-F0-9-]{36})"? ?[)}]/.exec(
           part,
         );
       if (match?.groups?.kid && match.groups.eid) {


### PR DESCRIPTION
Some models generate invalid JSON without quotes around the values of the JSON string:
- Make quotes optional in the RegEx to properly recognize those source refs as well.
- Accept normal braces instead of curly braces.