### PR TITLE
Implement jump to & highlight source when opening PDF

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -180,6 +180,10 @@
           "embeddingId" : {
             "$ref" : "#/components/schemas/UUID"
           },
+          "page" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
           "content" : {
             "type" : "string"
           }
@@ -1133,7 +1137,7 @@
   },
   "info" : {
     "title" : "LLAMARA API",
-    "version" : "0.6.1-SNAPSHOT",
+    "version" : "0.7.1-SNAPSHOT",
     "description" : "The official REST API for LLAMARA - the Large Language Assistant for Model Augmented Retrieval and Analysis - an LLM-based assistant for information retrieval from a provided knowledge base.",
     "contact" : {
       "name" : "LLAMARA GitHub Organization",

--- a/src/api/types.gen.ts
+++ b/src/api/types.gen.ts
@@ -68,6 +68,7 @@ export type Permission = 'OWNER' | 'READWRITE' | 'READONLY' | 'NONE';
 export type RagSourceRecord = {
     knowledgeId?: Uuid;
     embeddingId?: Uuid;
+    page?: number;
     content?: string;
 };
 

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -37,9 +37,24 @@ interface SearchResult {
   text: string;
 }
 
-function highlightPattern(text: string, query: string): string {
-  const regex = new RegExp(query, "gi"); // 'g' for global, 'i' for case-insensitive
-  return text.replace(regex, (value) => `<mark>${value}</mark>`);
+/**
+ * Highlights the given text based on the given query.
+ * The query is split up by line breaks and extra whitespace and each segment is highlighted.
+ * This might highlight more than the query itself, but it highlights the full query.
+ *
+ * @param text the text to apply the highlighting to
+ * @param query the query to highlight
+ */
+function highlightSearch(text: string, query: string): string {
+  // split the query by line breaks and extra whitespace
+  const regexes = query
+    .split(/([\r\n]|\s{2,})+/)
+    //.map(s => s.trim())
+    .map((s) => new RegExp(s, "gi")); // 'g' is for global, 'i' is for case-insensitive
+  // highlight the individual query segments
+  return regexes.reduce((acc, regex) => {
+    return acc.replace(regex, (value) => `<mark>${value}</mark>`);
+  }, text);
 }
 
 const PdfViewer = ({
@@ -295,8 +310,8 @@ const PdfViewer = ({
   }, [pageRefs, containerRef]); // Added missing dependencies
 
   const textRenderer = useCallback(
-    (textItem: TextItem) => highlightPattern(textItem.str, searchQuery),
-    [searchQuery, searchResults, currentSearchIndex],
+    (textItem: TextItem) => highlightSearch(textItem.str, searchQuery),
+    [searchQuery],
   );
 
   useEffect(() => {

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import type { PDFDocumentProxy } from "pdfjs-dist";
 import printJS from "print-js";
-import type { TextItem } from "pdfjs-dist/types/src/display/api";
+import type { TextItem, PDFPageProxy } from "pdfjs-dist/types/src/display/api";
 import { t } from "i18next";
 
 interface PdfViewerProps {
@@ -194,13 +194,17 @@ const PdfViewer = ({
     term = normalizeText(term).toLowerCase();
     const results: SearchResult[] = [];
 
-    for (let pageIndex = 0; pageIndex < pdfDocument.numPages; pageIndex++) {
-      const page = await pdfDocument.getPage(pageIndex + 1);
+    async function getPageText(page: PDFPageProxy): Promise<string> {
       const textContent = await page.getTextContent();
-      const pageText = textContent.items
+      return textContent.items
         .filter((item): item is TextItem => "str" in item)
         .map((item: TextItem) => item.str)
         .join(" ");
+    }
+
+    for (let pageIndex = 0; pageIndex < pdfDocument.numPages; pageIndex++) {
+      const page = await pdfDocument.getPage(pageIndex - 1);
+      const pageText = await getPageText(page);
 
       let matchIndex = 0;
       let index = normalizeText(pageText).toLowerCase().indexOf(term);

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -38,6 +38,18 @@ interface SearchResult {
 }
 
 /**
+ * Normalizes text by removing line breaks and extra whitespace.
+ *
+ * @param text the normalized text
+ */
+function normalizeText(text: string): string {
+  return text
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
  * Highlights the given text based on the given query.
  * The query is split up by line breaks and extra whitespace and each segment is highlighted.
  * This might highlight more than the query itself, but it highlights the full query.
@@ -179,6 +191,7 @@ const PdfViewer = ({
 
     setSearchQuery(term);
 
+    term = normalizeText(term).toLowerCase();
     const results: SearchResult[] = [];
 
     for (let pageIndex = 0; pageIndex < pdfDocument.numPages; pageIndex++) {
@@ -190,7 +203,7 @@ const PdfViewer = ({
         .join(" ");
 
       let matchIndex = 0;
-      let index = pageText.toLowerCase().indexOf(term.toLowerCase());
+      let index = normalizeText(pageText).toLowerCase().indexOf(term);
 
       while (index !== -1) {
         results.push({
@@ -198,7 +211,9 @@ const PdfViewer = ({
           matchIndex: matchIndex++,
           text: pageText.substring(index, index + term.length),
         });
-        index = pageText.toLowerCase().indexOf(term.toLowerCase(), index + 1);
+        index = normalizeText(pageText)
+          .toLowerCase()
+          .indexOf(term, index + 1);
       }
     }
 

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -20,6 +20,7 @@ import { t } from "i18next";
 interface PdfViewerProps {
   fileUuid: string;
   label: string;
+  initialSearchQuery?: string;
   collapseToolbarButtonsBreakpoint?: number;
 }
 
@@ -44,6 +45,7 @@ function highlightPattern(text: string, query: string): string {
 const PdfViewer = ({
   fileUuid,
   label,
+  initialSearchQuery,
   collapseToolbarButtonsBreakpoint,
 }: PdfViewerProps) => {
   const { fileData } = useGetKnowledgeFileApi({ uuid: fileUuid });
@@ -327,6 +329,14 @@ const PdfViewer = ({
       }
     };
   }, [observer]);
+
+  useEffect(() => {
+    if (pdfDocument) {
+      if (initialSearchQuery) {
+        void handleSearch(initialSearchQuery, 150);
+      }
+    }
+  }, [pdfDocument]);
 
   return (
     <div className="w-full h-full flex flex-col bg-transparent">

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -452,7 +452,7 @@ const PdfViewer = ({
                 className="mb-4"
               >
                 <Page
-                  customTextRenderer={textRenderer}
+                  customTextRenderer={index + 1 === initialPage || searchResults.map(s => s.pageIndex).includes(index) ? textRenderer : undefined}
                   pageNumber={index + 1}
                   scale={scale}
                   rotate={rotation}

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -20,7 +20,8 @@ import { t } from "i18next";
 interface PdfViewerProps {
   fileUuid: string;
   label: string;
-  initialSearchQuery?: string;
+  initialPage?: number;
+  initialHighlightQuery?: string;
   collapseToolbarButtonsBreakpoint?: number;
 }
 
@@ -72,7 +73,8 @@ function highlightSearch(text: string, query: string): string {
 const PdfViewer = ({
   fileUuid,
   label,
-  initialSearchQuery,
+  initialPage,
+  initialHighlightQuery,
   collapseToolbarButtonsBreakpoint,
 }: PdfViewerProps) => {
   const { fileData } = useGetKnowledgeFileApi({ uuid: fileUuid });
@@ -392,13 +394,19 @@ const PdfViewer = ({
     };
   }, [observer]);
 
-  useEffect(() => {
+  const handleInitialProps = () => {
     if (pdfDocument) {
-      if (initialSearchQuery) {
-        void handleSearch(initialSearchQuery, 150);
+      if (initialPage) {
+        setCurrentPage(initialPage);
+        scrollToPage(initialPage);
+        if (initialHighlightQuery) setSearchQuery(initialHighlightQuery);
       }
     }
-  }, [pdfDocument]);
+  }
+
+  useEffect(() => {
+    handleInitialProps();
+  }, [initialPage, initialHighlightQuery]);
 
   return (
     <div className="w-full h-full flex flex-col bg-transparent">
@@ -461,6 +469,7 @@ const PdfViewer = ({
                   onRenderSuccess={() => {
                     if (index === 0) {
                       setCurrentPage(1);
+                      handleInitialProps();
                     }
                   }}
                 />

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -59,7 +59,7 @@ const regexCache = new Map<string, RegExp>();
  * @returns {string} - The cleaned query.
  */
 function removeNonWordCharacters(query: string): string {
-  return query.replace(/\W+/g, ' ');
+  return query.replace(/\W+/g, " ");
 }
 
 /**
@@ -67,7 +67,7 @@ function removeNonWordCharacters(query: string): string {
  * @param query the query to escape
  */
 function escapeRegExp(query: string): string {
-  return query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
@@ -78,14 +78,14 @@ function buildPartialMultiWordPattern(query: string): string {
   const words = query.trim().split(/\s+/);
 
   if (words.length < 3) {
-    return words.join('.*?');
+    return words.join(".*?");
   }
 
-  let pattern = '';
+  let pattern = "";
   for (let i = 0; i < 3; i++) {
     pattern += `(?=.*?${words[i]})`;
   }
-  return pattern + '.*';
+  return pattern + ".*";
 }
 
 /**
@@ -106,7 +106,7 @@ function highlightSearch(text: string, query: string): string {
     const segmentRegex = /(?:[\r\n]|\t|\s{2,})+/;
 
     // Using a single loop for all operations (split, trim, clean, escape, build pattern)
-    query.split(segmentRegex).forEach(segment => {
+    query.split(segmentRegex).forEach((segment) => {
       const trimmed = segment.trim();
       if (trimmed) {
         const cleaned = removeNonWordCharacters(trimmed);
@@ -119,7 +119,7 @@ function highlightSearch(text: string, query: string): string {
     if (segments.length === 0) return text;
 
     // Combine segments into a single regex and cache it
-    regex = new RegExp(`(${segments.join('|')})`, 'gi');
+    regex = new RegExp(`(${segments.join("|")})`, "gi");
     regexCache.set(query, regex);
   }
 
@@ -249,7 +249,7 @@ const PdfViewer = ({
       setCurrentPage(firstResultPage);
       scrollToPage(firstResultPage);
     }
-  }
+  };
 
   /**
    * Handles the search for the given term.
@@ -291,7 +291,9 @@ const PdfViewer = ({
     };
 
     // Process pages concurrently but preserve order
-    const pagePromises = Array.from({ length: pdfDocument.numPages }, (_, i) => pdfDocument.getPage(i + 1).then(page => getPageText(page, i)));
+    const pagePromises = Array.from({ length: pdfDocument.numPages }, (_, i) =>
+      pdfDocument.getPage(i + 1).then((page) => getPageText(page, i)),
+    );
     const pagesWithText = await Promise.all(pagePromises);
 
     results = [];
@@ -309,7 +311,7 @@ const PdfViewer = ({
         });
         index = normalizedPageText.indexOf(normalizedTerm, index + 1);
       }
-    })
+    });
 
     // Store the results in cache
     searchCache.set(cacheKey, results);
@@ -459,7 +461,7 @@ const PdfViewer = ({
         if (initialHighlightQuery) setSearchQuery(initialHighlightQuery);
       }
     }
-  }
+  };
 
   useEffect(() => {
     handleInitialProps();
@@ -509,7 +511,12 @@ const PdfViewer = ({
                 className="mb-4"
               >
                 <Page
-                  customTextRenderer={(index + 1 === initialPage || searchResults.map(s => s.pageIndex).includes(index)) ? textRenderer : undefined}
+                  customTextRenderer={
+                    index + 1 === initialPage ||
+                    searchResults.map((s) => s.pageIndex).includes(index)
+                      ? textRenderer
+                      : undefined
+                  }
                   pageNumber={index + 1}
                   scale={scale}
                   rotate={rotation}

--- a/src/components/pdf-viewer.tsx
+++ b/src/components/pdf-viewer.tsx
@@ -509,7 +509,7 @@ const PdfViewer = ({
                 className="mb-4"
               >
                 <Page
-                  customTextRenderer={index + 1 === initialPage || searchResults.map(s => s.pageIndex).includes(index) ? textRenderer : undefined}
+                  customTextRenderer={(index + 1 === initialPage || searchResults.map(s => s.pageIndex).includes(index)) ? textRenderer : undefined}
                   pageNumber={index + 1}
                   scale={scale}
                   rotate={rotation}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -38,6 +38,7 @@
           "startedTitle": "Download gestartet",
           "startedDescription": "Der Download wurde gestartet."
         },
+        "page": "Seite",
         "error": {
           "generic": "Es ist ein Fehler aufgetreten."
         }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -38,6 +38,7 @@
           "startedTitle": "Download Started",
           "startedDescription": "The download has started."
         },
+        "page": "Page",
         "error": {
           "generic": "An error occurred."
         }

--- a/src/views/chatbot/Chat.tsx
+++ b/src/views/chatbot/Chat.tsx
@@ -19,7 +19,7 @@ interface ChatProps {
   isLoading: boolean;
   isGenerating: boolean;
   lockSendPrompt: boolean;
-  openPdf: (uuid: string, label: string) => void;
+  openPdf: (uuid: string, label: string, search?: string) => void;
 }
 
 export default function Chat({

--- a/src/views/chatbot/Chat.tsx
+++ b/src/views/chatbot/Chat.tsx
@@ -13,7 +13,12 @@ import PromptInput from "./PromptInput";
 import { readSelectedModel } from "@/hooks/useLocalStorage";
 import { useIsMobile } from "@/hooks/useMobile";
 
-export type openPdf = (uuid: string, label: string, initialPage?: number, initialHighlightQuery?: string) => void;
+export type openPdf = (
+  uuid: string,
+  label: string,
+  initialPage?: number,
+  initialHighlightQuery?: string,
+) => void;
 
 interface ChatProps {
   messages: ChatMessageRecord[];

--- a/src/views/chatbot/Chat.tsx
+++ b/src/views/chatbot/Chat.tsx
@@ -13,13 +13,15 @@ import PromptInput from "./PromptInput";
 import { readSelectedModel } from "@/hooks/useLocalStorage";
 import { useIsMobile } from "@/hooks/useMobile";
 
+export type openPdf = (uuid: string, label: string, initialPage?: number, initialHighlightQuery?: string) => void;
+
 interface ChatProps {
   messages: ChatMessageRecord[];
   handleSubmit: (prompt: string) => Promise<void>;
   isLoading: boolean;
   isGenerating: boolean;
   lockSendPrompt: boolean;
-  openPdf: (uuid: string, label: string, search?: string) => void;
+  openPdf: openPdf;
 }
 
 export default function Chat({

--- a/src/views/chatbot/ChatMessage.tsx
+++ b/src/views/chatbot/ChatMessage.tsx
@@ -25,12 +25,13 @@ import {
 } from "@/components/ui/tooltip";
 import useAvailableModels from "@/hooks/api/useGetModelsApi";
 import { KnowledgeSource } from "./KnowledgeSource";
+import { openPdf } from "@/views/chatbot/Chat.tsx";
 
 interface ChatMessageProps {
   message: ChatMessageRecord;
   isGenerating: boolean;
   handleRetryClick: () => void;
-  openPdf: (uuid: string, label: string, search?: string) => void;
+  openPdf: openPdf;
   showButtons: boolean;
   className?: string;
 }
@@ -178,7 +179,7 @@ export default function ChatMessage({
 interface KnowledgeSourceRendererProps {
   children: React.ReactNode;
   sources: RagSourceRecord[] | undefined;
-  openPdf: (uuid: string, label: string, search?: string) => void;
+  openPdf: openPdf;
 }
 
 function KnowledgeSourceRenderer({

--- a/src/views/chatbot/ChatMessage.tsx
+++ b/src/views/chatbot/ChatMessage.tsx
@@ -30,7 +30,7 @@ interface ChatMessageProps {
   message: ChatMessageRecord;
   isGenerating: boolean;
   handleRetryClick: () => void;
-  openPdf: (uuid: string, label: string) => void;
+  openPdf: (uuid: string, label: string, search?: string) => void;
   showButtons: boolean;
   className?: string;
 }
@@ -178,7 +178,7 @@ export default function ChatMessage({
 interface KnowledgeSourceRendererProps {
   children: React.ReactNode;
   sources: RagSourceRecord[] | undefined;
-  openPdf: (uuid: string, label: string) => void;
+  openPdf: (uuid: string, label: string, search?: string) => void;
 }
 
 function KnowledgeSourceRenderer({

--- a/src/views/chatbot/Chatbot.tsx
+++ b/src/views/chatbot/Chatbot.tsx
@@ -18,9 +18,10 @@ const COLLAPSE_SIDEBAR_BREAKPOINT = 1340;
 export default function Chatbot() {
   const [pdfKnowledgeId, setPdfKnowledgeId] = useState<string | null>(null);
   const [pdfFileName, setPdfFileName] = useState<string | null>(null);
-  const [pdfSearchQuery, setPdfSearchQuery] = useState<string | undefined>(
+  const [initialPdfPage, setInitialPdfPage] = useState<number | undefined>(
     undefined,
   );
+  const [initialPdfHighlightQuery, setInitialPdfHighlightQuery] = useState<string | undefined>(undefined);
   const [autoCollapsedSidebar, setAutoCollapsedSidebar] = useState(false);
   const { setActiveSessionId } = useGetSessions();
   useKeepAliveSession();
@@ -94,10 +95,11 @@ export default function Chatbot() {
           isLoading={loadingHistory}
           isGenerating={loadingResponse}
           lockSendPrompt={false}
-          openPdf={(uuid: string, label: string, search?: string) => {
+          openPdf={(uuid: string, label: string, initialPage?: number, initialHighlightQuery?: string) => {
             setPdfKnowledgeId(uuid);
             setPdfFileName(label);
-            setPdfSearchQuery(search);
+            setInitialPdfPage(initialPage);
+            setInitialPdfHighlightQuery(initialHighlightQuery);
           }}
         />
       </div>
@@ -129,7 +131,8 @@ export default function Chatbot() {
             <PdfViewer
               fileUuid={pdfKnowledgeId}
               label={pdfFileName}
-              initialSearchQuery={pdfSearchQuery}
+              initialPage={initialPdfPage}
+              initialHighlightQuery={initialPdfHighlightQuery}
               collapseToolbarButtonsBreakpoint={open ? 1490 : 1240}
             />
           </div>

--- a/src/views/chatbot/Chatbot.tsx
+++ b/src/views/chatbot/Chatbot.tsx
@@ -21,7 +21,9 @@ export default function Chatbot() {
   const [initialPdfPage, setInitialPdfPage] = useState<number | undefined>(
     undefined,
   );
-  const [initialPdfHighlightQuery, setInitialPdfHighlightQuery] = useState<string | undefined>(undefined);
+  const [initialPdfHighlightQuery, setInitialPdfHighlightQuery] = useState<
+    string | undefined
+  >(undefined);
   const [autoCollapsedSidebar, setAutoCollapsedSidebar] = useState(false);
   const { setActiveSessionId } = useGetSessions();
   useKeepAliveSession();
@@ -95,7 +97,12 @@ export default function Chatbot() {
           isLoading={loadingHistory}
           isGenerating={loadingResponse}
           lockSendPrompt={false}
-          openPdf={(uuid: string, label: string, initialPage?: number, initialHighlightQuery?: string) => {
+          openPdf={(
+            uuid: string,
+            label: string,
+            initialPage?: number,
+            initialHighlightQuery?: string,
+          ) => {
             setPdfKnowledgeId(uuid);
             setPdfFileName(label);
             setInitialPdfPage(initialPage);

--- a/src/views/chatbot/Chatbot.tsx
+++ b/src/views/chatbot/Chatbot.tsx
@@ -18,6 +18,9 @@ const COLLAPSE_SIDEBAR_BREAKPOINT = 1340;
 export default function Chatbot() {
   const [pdfKnowledgeId, setPdfKnowledgeId] = useState<string | null>(null);
   const [pdfFileName, setPdfFileName] = useState<string | null>(null);
+  const [pdfSearchQuery, setPdfSearchQuery] = useState<string | undefined>(
+    undefined,
+  );
   const [autoCollapsedSidebar, setAutoCollapsedSidebar] = useState(false);
   const { setActiveSessionId } = useGetSessions();
   useKeepAliveSession();
@@ -91,9 +94,10 @@ export default function Chatbot() {
           isLoading={loadingHistory}
           isGenerating={loadingResponse}
           lockSendPrompt={false}
-          openPdf={(uuid: string, label: string) => {
+          openPdf={(uuid: string, label: string, search?: string) => {
             setPdfKnowledgeId(uuid);
             setPdfFileName(label);
+            setPdfSearchQuery(search);
           }}
         />
       </div>
@@ -125,6 +129,7 @@ export default function Chatbot() {
             <PdfViewer
               fileUuid={pdfKnowledgeId}
               label={pdfFileName}
+              initialSearchQuery={pdfSearchQuery}
               collapseToolbarButtonsBreakpoint={open ? 1490 : 1240}
             />
           </div>

--- a/src/views/chatbot/KnowledgeSource.tsx
+++ b/src/views/chatbot/KnowledgeSource.tsx
@@ -7,12 +7,13 @@ import { KnowledgeSourceDetail } from "./KnowledgeSourceDetail";
 import React, { useState } from "react";
 import { useIsTouch } from "@/hooks/useIsTouch.ts";
 import { useHandleClickOutside } from "@/hooks/useHandleClickOutside.ts";
+import { openPdf } from "@/views/chatbot/Chat.tsx";
 
 interface KnowledgeSourceProps {
   knowledgeId: string | null;
   embeddingId: string | null;
   sources: RagSourceRecord[] | undefined;
-  openPdf: (uuid: string, label: string, search?: string) => void;
+  openPdf: openPdf;
 }
 
 export interface HoverProps {
@@ -58,8 +59,7 @@ export function KnowledgeSource({
     const docType = knowledge?.label?.split(".").pop()?.toLowerCase();
 
     if (docType === "pdf") {
-      const source = sourceContent?.content;
-      openPdf(knowledgeId, knowledge?.label ?? "document", source);
+      openPdf(knowledgeId, knowledge?.label ?? "document", sourceContent?.page, sourceContent?.content);
       return;
     }
     await downloadFile(knowledgeId, knowledge?.label);

--- a/src/views/chatbot/KnowledgeSource.tsx
+++ b/src/views/chatbot/KnowledgeSource.tsx
@@ -59,7 +59,12 @@ export function KnowledgeSource({
     const docType = knowledge?.label?.split(".").pop()?.toLowerCase();
 
     if (docType === "pdf") {
-      openPdf(knowledgeId, knowledge?.label ?? "document", sourceContent?.page, sourceContent?.content);
+      openPdf(
+        knowledgeId,
+        knowledge?.label ?? "document",
+        sourceContent?.page,
+        sourceContent?.content,
+      );
       return;
     }
     await downloadFile(knowledgeId, knowledge?.label);

--- a/src/views/chatbot/KnowledgeSource.tsx
+++ b/src/views/chatbot/KnowledgeSource.tsx
@@ -12,7 +12,7 @@ interface KnowledgeSourceProps {
   knowledgeId: string | null;
   embeddingId: string | null;
   sources: RagSourceRecord[] | undefined;
-  openPdf: (uuid: string, label: string) => void;
+  openPdf: (uuid: string, label: string, search?: string) => void;
 }
 
 export interface HoverProps {
@@ -48,21 +48,22 @@ export function KnowledgeSource({
     return t("chatbot.chat.source.docTypeUnknown");
   };
 
+  const sourceContent = sources?.find(
+    (source) => source.embeddingId === embeddingId,
+  );
+
   const handleFileSource = async (): Promise<void> => {
     if (!knowledgeId || error) return;
 
     const docType = knowledge?.label?.split(".").pop()?.toLowerCase();
 
     if (docType === "pdf") {
-      openPdf(knowledgeId, knowledge?.label ?? "document");
+      const source = sourceContent?.content;
+      openPdf(knowledgeId, knowledge?.label ?? "document", source);
       return;
     }
     await downloadFile(knowledgeId, knowledge?.label);
   };
-
-  const sourceContent = sources?.find(
-    (source) => source.embeddingId === embeddingId,
-  );
 
   const handleClick = () => {
     if (isTouch) {

--- a/src/views/chatbot/KnowledgeSourceDetail.tsx
+++ b/src/views/chatbot/KnowledgeSourceDetail.tsx
@@ -1,6 +1,5 @@
 import {
   CardContent,
-  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -37,14 +36,9 @@ export function KnowledgeSourceDetail({
         {knowledge && (
           <div className="flex flex-row justify-between">
             <div>
-              <CardTitle className="text-lg">{knowledge.label}</CardTitle>
-              {hoverProps.source?.page && (
-                <CardDescription>
-                  {t("chatbot.chat.source.page") +
-                    ": " +
-                    hoverProps.source.page.toString()}
-                </CardDescription>
-              )}
+              <CardTitle className="font-bold text-lg">
+                {knowledge.label}
+              </CardTitle>
             </div>
             <Button onClick={onOpenFile} className="h-10 w-10">
               <FileSymlink className="h-8 w-8" />
@@ -100,10 +94,17 @@ export function KnowledgeSourceDetail({
         <hr />
       </CardContent>
       <CardFooter className="p-0 pt-4">
-        <div className="flex flex-col items-start ">
-          <h3 className="font-bold mb-2 underline">
-            {t("knowledge.sourceContent")}
-          </h3>
+        <div className="flex flex-col items-start">
+          <div className="flex flex-col mb-2">
+            <h3 className="font-bold leading-tight">
+              {t("knowledge.sourceContent")}
+            </h3>
+            {hoverProps.source?.page && (
+              <p className="text-sm text-muted-foreground">
+                {t("chatbot.chat.source.page") + ": " + hoverProps.source.page}
+              </p>
+            )}
+          </div>
           <p className="text-sm whitespace-pre-wrap">{sourceContent}</p>
         </div>
       </CardFooter>

--- a/src/views/chatbot/KnowledgeSourceDetail.tsx
+++ b/src/views/chatbot/KnowledgeSourceDetail.tsx
@@ -42,7 +42,7 @@ export function KnowledgeSourceDetail({
                 <CardDescription>
                   {t("chatbot.chat.source.page") +
                     ": " +
-                    hoverProps.source.page}
+                    hoverProps.source.page.toString()}
                 </CardDescription>
               )}
             </div>

--- a/src/views/chatbot/KnowledgeSourceDetail.tsx
+++ b/src/views/chatbot/KnowledgeSourceDetail.tsx
@@ -8,7 +8,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { HoverCardContent } from "@/components/ui/hover-card";
 import { formatDate } from "@/lib/formatDate";
-import { t } from "i18next";
 import {
   translatePermissions,
   translateUser,
@@ -16,6 +15,7 @@ import {
 import { HoverProps } from "./KnowledgeSource";
 import { FileSymlink } from "lucide-react";
 import { Button } from "@/components/ui/button.tsx";
+import { useTranslation } from "react-i18next";
 
 interface KnowledgeCardProps {
   onOpenFile: () => void;
@@ -26,6 +26,7 @@ export function KnowledgeSourceDetail({
   onOpenFile,
   hoverProps,
 }: Readonly<KnowledgeCardProps>) {
+  const { t } = useTranslation();
   const knowledge = hoverProps.knowledge;
   const sourceContent =
     hoverProps.source?.content ?? "No source content available";
@@ -36,8 +37,14 @@ export function KnowledgeSourceDetail({
         {knowledge && (
           <div className="flex flex-row justify-between">
             <div>
-              <CardTitle className="underline">{knowledge.label}</CardTitle>
-              <CardDescription>ID: {knowledge.id}</CardDescription>
+              <CardTitle className="text-lg">{knowledge.label}</CardTitle>
+              {hoverProps.source?.page && (
+                <CardDescription>
+                  {t("chatbot.chat.source.page") +
+                    ": " +
+                    hoverProps.source.page}
+                </CardDescription>
+              )}
             </div>
             <Button onClick={onOpenFile} className="h-10 w-10">
               <FileSymlink className="h-8 w-8" />


### PR DESCRIPTION
Resolves #22.

With this change, the PDF viewer will now jump to and highlight the text of the source that has been clicked to open the PDF.
This involves several implementation steps:
- Support passing initial page and highlight query to PDF viewer.
- Pass the source page & text as as initial props the PDF viewer when opening it.
- Ignore line breaks and extra whitespace when highlighting search query in PDF viewer. Whilst this highlights some additional stuff, it is needed to highlight the full source text.
- Only use the highlight renderer on the initial page and search result pages for better performance.
- Normalize text and search query when searching, i.e. remove line breaks and extra whitespace, to improve search results.
- Improve performance of search and highlighting and cache results and compiled regexes.
- Improve quality of highlighting.