### PR TITLE
Chat: Fix safe-areas insets not respected & Fix overscroll behaviour

### DIFF
--- a/src/views/chatbot/Chatbot.tsx
+++ b/src/views/chatbot/Chatbot.tsx
@@ -87,9 +87,9 @@ export default function Chatbot() {
   };
 
   return (
-    <div className="flex h-full pt-1 justify-center">
+    <div className="flex h-full pt-[var(--header-height)] xl:pt-1 justify-center overscroll-contain touch-none">
       <div
-        className={`flex-shrink transition-all duration-300 ${pdfKnowledgeId != null ? "mr-4" : "w-full lg:w-5/6"} h-full overflow-auto`}
+        className={`flex-shrink transition-all duration-300 overscroll-contain touch-none ${pdfKnowledgeId != null ? "mr-4" : "w-full lg:w-5/6"} h-full overflow-auto`}
       >
         <Chat
           messages={chatMessages}

--- a/src/views/overlays/Footer.tsx
+++ b/src/views/overlays/Footer.tsx
@@ -6,7 +6,12 @@ export default function Footer() {
   const { t } = useTranslation();
 
   return (
-    <footer className="pb-1 text-center">
+    <footer
+      className="text-center"
+      style={{
+        paddingBottom: "env(safe-area-inset-bottom, 0.25rem)",
+      }}
+    >
       {(imprintUrl ?? privacyPolicyUrl) && (
         <nav className="flex flex-row justify-center gap-4">
           {imprintUrl && (

--- a/src/views/overlays/Header.tsx
+++ b/src/views/overlays/Header.tsx
@@ -23,7 +23,12 @@ export default function Header({ onClickNewSession }: Readonly<Header>) {
   const { user } = useUserContext();
 
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
+    <header
+      className="flex h-12 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12"
+      style={{
+        paddingTop: "env(safe-area-inset-top, 0px)",
+      }}
+    >
       <div className="flex items-center gap-2 px-4">
         <SidebarTrigger className="-ml-1" />
         {(user?.name ?? user?.username) && (

--- a/src/views/overlays/Overlay.tsx
+++ b/src/views/overlays/Overlay.tsx
@@ -34,7 +34,7 @@ export function Overlay({ children, contentToTop }: Readonly<OverlayProps>) {
         />
       </div>
       <div
-        className="mx-4 overflow-y-auto"
+        className="mx-4 overflow-y-auto overscroll-contain touch-none"
         style={
           {
             "--header-height": `${headerSize.height.toString()}px`,


### PR DESCRIPTION
- Fix footer does not respect safe area.
- Adjust header to respect safe-area if there is any.
- Fix chat messages unreadable behind header on tighter screens.
- Disable pull to refresh on touch devices.