### PR TITLE
`useIsMobile`: Take the smaller edge into account instead of both edges

### DIFF
--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -9,11 +9,11 @@ export function useIsMobile() {
   });
 
   const [isMobile, setIsMobile] = useState<boolean>(
-    width < MOBILE_BREAKPOINT || height < MOBILE_BREAKPOINT,
+    Math.min(width, height) < MOBILE_BREAKPOINT,
   );
 
   useEffect(() => {
-    setIsMobile(width < MOBILE_BREAKPOINT || height < MOBILE_BREAKPOINT);
+    setIsMobile(Math.min(width, height) < MOBILE_BREAKPOINT);
   }, [width]);
 
   return isMobile;


### PR DESCRIPTION
Minor code improvement, makes the code easier to understand IMO.